### PR TITLE
Fix GradualEvaluation percentage check

### DIFF
--- a/libs/utils/src/main/kotlin/no/utgdev/juuffs/FeatureToggles.kt
+++ b/libs/utils/src/main/kotlin/no/utgdev/juuffs/FeatureToggles.kt
@@ -89,7 +89,7 @@ object FeatureToggles {
         @Serializable
         @SerialName("gradual")
         data class GradualEvaluation(val percentage: Int): Evaluation {
-            override fun isEnabled(ctx: Context): Boolean = Random.nextInt(0..100) < percentage
+            override fun isEnabled(ctx: Context): Boolean = Random.nextInt(0, 100) < percentage
         }
     }
 


### PR DESCRIPTION
## Summary
- fix off-by-one bug when evaluating gradual feature toggles

## Testing
- `gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d286ebdb48333b29ef9d16ef27bdb