### PR TITLE
Add FeatureToggles evaluation tests

### DIFF
--- a/libs/utils/src/main/kotlin/no/utgdev/juuffs/FeatureToggles.kt
+++ b/libs/utils/src/main/kotlin/no/utgdev/juuffs/FeatureToggles.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.utgdev.utils.no.utgdev.juuffs.FeatureToggles.ContraintOperator.LIST_CONTAINS
 import kotlin.random.Random
-import kotlin.random.nextInt
 
 object FeatureToggles {
     @Serializable
@@ -88,8 +87,11 @@ object FeatureToggles {
 
         @Serializable
         @SerialName("gradual")
-        data class GradualEvaluation(val percentage: Int): Evaluation {
-            override fun isEnabled(ctx: Context): Boolean = Random.nextInt(0, 100) < percentage
+        data class GradualEvaluation(
+            val percentage: Int,
+            val random: Random = Random.Default,
+        ) : Evaluation {
+            override fun isEnabled(ctx: Context): Boolean = random.nextInt(0, 100) < percentage
         }
     }
 
@@ -156,8 +158,8 @@ object FeatureToggles {
             evaluation = Evaluation.FixedEvaluation(isEnabled = isEnabled)
         }
 
-        fun gradual(percentage: Int) {
-            evaluation = Evaluation.GradualEvaluation(percentage)
+        fun gradual(percentage: Int, random: Random = Random.Default) {
+            evaluation = Evaluation.GradualEvaluation(percentage, random)
         }
 
         fun build(): Evaluation = evaluation

--- a/libs/utils/src/test/kotlin/no/utgdev/juuffs/FeatureTogglesTest.kt
+++ b/libs/utils/src/test/kotlin/no/utgdev/juuffs/FeatureTogglesTest.kt
@@ -1,12 +1,78 @@
 package no.utgdev.utils.no.utgdev.juuffs
 
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-
+import kotlin.random.Random
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class FeatureTogglesTest {
+
+    private class FixedRandom(private val value: Int) : Random() {
+        override fun nextBits(bitCount: Int): Int = value
+        override fun nextInt(from: Int, until: Int): Int = value
+    }
+
     @Test
-    fun `should create some tests`() {
-        assertEquals("hei", "hei")
+    fun `equals operator succeeds when values match`() {
+        val ctx = FeatureToggles.Context(mapOf("user" to "123"))
+        val constraint = FeatureToggles.Contraint.Comparison(
+            "user",
+            FeatureToggles.ContraintOperator.EQUALS,
+            "123"
+        )
+
+        assertTrue(constraint.evaluate(ctx))
+    }
+
+    @Test
+    fun `equals operator fails when values do not match`() {
+        val ctx = FeatureToggles.Context(mapOf("user" to "456"))
+        val constraint = FeatureToggles.Contraint.Comparison(
+            "user",
+            FeatureToggles.ContraintOperator.EQUALS,
+            "123"
+        )
+
+        assertFalse(constraint.evaluate(ctx))
+    }
+
+    @Test
+    fun `list contains operator succeeds when value exists`() {
+        val ctx = FeatureToggles.Context(mapOf("groups" to "a, b, c"))
+        val constraint = FeatureToggles.Contraint.Comparison(
+            "groups",
+            FeatureToggles.ContraintOperator.LIST_CONTAINS,
+            "b"
+        )
+
+        assertTrue(constraint.evaluate(ctx))
+    }
+
+    @Test
+    fun `list contains operator fails when value missing`() {
+        val ctx = FeatureToggles.Context(mapOf("groups" to "a, b, c"))
+        val constraint = FeatureToggles.Contraint.Comparison(
+            "groups",
+            FeatureToggles.ContraintOperator.LIST_CONTAINS,
+            "d"
+        )
+
+        assertFalse(constraint.evaluate(ctx))
+    }
+
+    @Test
+    fun `gradual evaluation returns true when random below percentage`() {
+        val evaluation = FeatureToggles.Evaluation.GradualEvaluation(50, FixedRandom(10))
+        val enabled = evaluation.isEnabled(FeatureToggles.Context.Empty)
+
+        assertTrue(enabled)
+    }
+
+    @Test
+    fun `gradual evaluation returns false when random above percentage`() {
+        val evaluation = FeatureToggles.Evaluation.GradualEvaluation(50, FixedRandom(90))
+        val enabled = evaluation.isEnabled(FeatureToggles.Context.Empty)
+
+        assertFalse(enabled)
     }
 }


### PR DESCRIPTION
## Summary
- expand `GradualEvaluation` with an injectable `Random`
- support custom random in the DSL
- add unit tests for constraint operators and gradual evaluation

## Testing
- `./gradlew :libs:utils:test --no-daemon` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685d2a6607848333937e12b7a8107e2a