### PR TITLE
Add FeatureToggles evaluation tests

### DIFF
--- a/libs/utils/src/main/kotlin/no/utgdev/juuffs/FeatureToggles.kt
+++ b/libs/utils/src/main/kotlin/no/utgdev/juuffs/FeatureToggles.kt
@@ -2,6 +2,7 @@ package no.utgdev.utils.no.utgdev.juuffs
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import no.utgdev.utils.no.utgdev.juuffs.FeatureToggles.ContraintOperator.LIST_CONTAINS
 import kotlin.random.Random
 import kotlin.random.nextInt
@@ -88,8 +89,11 @@ object FeatureToggles {
 
         @Serializable
         @SerialName("gradual")
-        data class GradualEvaluation(val percentage: Int): Evaluation {
-            override fun isEnabled(ctx: Context): Boolean = Random.nextInt(0, 100) < percentage
+        data class GradualEvaluation(
+            val percentage: Int,
+            @Transient val random: Random = Random.Default,
+        ) : Evaluation {
+            override fun isEnabled(ctx: Context): Boolean = random.nextInt(0, 100) < percentage
         }
     }
 
@@ -156,8 +160,8 @@ object FeatureToggles {
             evaluation = Evaluation.FixedEvaluation(isEnabled = isEnabled)
         }
 
-        fun gradual(percentage: Int) {
-            evaluation = Evaluation.GradualEvaluation(percentage)
+        fun gradual(percentage: Int, random: Random = Random.Default) {
+            evaluation = Evaluation.GradualEvaluation(percentage, random)
         }
 
         fun build(): Evaluation = evaluation

--- a/libs/utils/src/test/kotlin/no/utgdev/juuffs/FeatureTogglesTest.kt
+++ b/libs/utils/src/test/kotlin/no/utgdev/juuffs/FeatureTogglesTest.kt
@@ -1,12 +1,82 @@
 package no.utgdev.utils.no.utgdev.juuffs
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class FeatureTogglesTest {
+
     @Test
-    fun `should create some tests`() {
-        assertEquals("hei", "hei")
+    fun `variant evaluates to true when constraints satisfied`() {
+        val toggle = FeatureToggles.toggle("test") {
+            variant("v1") {
+                constraint { "role" equals "admin" }
+                evaluation { default(true) }
+            }
+        }
+
+        val ctx = FeatureToggles.Context(mapOf("role" to "admin"))
+        assertTrue(toggle.evaluate(ctx))
+    }
+
+    @Test
+    fun `variant evaluates to false when constraints not satisfied`() {
+        val toggle = FeatureToggles.toggle("test") {
+            variant("v1") {
+                constraint { "role" equals "admin" }
+                evaluation { default(true) }
+            }
+        }
+
+        val ctx = FeatureToggles.Context(mapOf("role" to "user"))
+        assertFalse(toggle.evaluate(ctx))
+    }
+
+    @Test
+    fun `listContains operator works`() {
+        val toggle = FeatureToggles.toggle("test") {
+            variant("v1") {
+                constraint { "roles" listContains "dev" }
+                evaluation { default(true) }
+            }
+        }
+
+        val ctx = FeatureToggles.Context(mapOf("roles" to "dev,admin"))
+        assertTrue(toggle.evaluate(ctx))
+    }
+
+    @Test
+    fun `gradual evaluation should be disabled if value is higher`() {
+        val rnd = StaticRandom(50)
+        val toggle = FeatureToggles.toggle("gradual") {
+            variant("v1") {
+                evaluation {
+                    gradual(10, rnd)
+                }
+            }
+        }
+
+        assertFalse(toggle.evaluate(FeatureToggles.Context.Empty))
+    }
+
+    @Test
+    fun `gradual evaluation should be enabled if value is lower`() {
+        val rnd = StaticRandom(50)
+        val toggle = FeatureToggles.toggle("gradual") {
+            variant("v1") {
+                evaluation {
+                    gradual(70, rnd)
+                }
+            }
+        }
+
+        assertTrue(toggle.evaluate(FeatureToggles.Context.Empty))
+    }
+
+    class StaticRandom(val value: Int) : Random() {
+        override fun nextBits(bitCount: Int): Int {
+            return value * 2
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inject `Random` instance into `GradualEvaluation`
- support the new parameter in the DSL builder
- add tests covering constraint evaluation and gradual rollout

## Testing
- `./gradlew libs:utils:test --rerun-tasks --no-daemon`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d3242aeb48333af7f41dd0015608f